### PR TITLE
fix: extension activation module resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"description": "A simple language server for mercurylang",
 	"author": "lilr",
 	"license": "MIT",
-	"version": "0.0.8",
+	"version": "0.0.9",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/JIM-GLITCH/mercury-ls"
@@ -19,7 +19,7 @@
 	"activationEvents": [
 		"onLanguage:mercury"
 	],
-	"main": "./client/out/extension",
+	"main": "./client/out/extension.js",
 	"contributes": {
 		"configuration": {
 			"type": "object",


### PR DESCRIPTION
## Summary
- fix extension entry entrypoint to include `.js` suffix in `main`

## Why
VS Code extension host failed to activate with:
`ERR_MODULE_NOT_FOUND` for `client/out/extension` under ESM resolution.

## Verification
- `npm run compile`
- `vsce package`